### PR TITLE
Change sleeping bag recipe to be more useful

### DIFF
--- a/scripts/OpenBlocks.zs
+++ b/scripts/OpenBlocks.zs
@@ -18,6 +18,7 @@
 	recipes.remove(<OpenBlocks:itemDropper>);
 	recipes.remove(<OpenBlocks:scaffolding>);
 	recipes.remove(<OpenBlocks:ropeladder>);
+	recipes.remove(<OpenBlocks:sleepingBag>);
     recipes.remove(<OpenBlocks:path>);
 
 // ================================================================================
@@ -37,3 +38,4 @@
 	recipes.addShaped(<OpenBlocks:ropeladder> * 16, [[<minecraft:string>, <ore:stickWood>, <minecraft:string>], [<minecraft:string>, <ore:stickWood>, <minecraft:string>], [<minecraft:string>, <ore:stickWood>, <minecraft:string>]]);
 	recipes.addShaped(<OpenBlocks:ropeladder> * 8, [[<ImmersiveEngineering:material:3>, <ore:stickWood>, <ImmersiveEngineering:material:3>], [<ImmersiveEngineering:material:3>, <ore:stickWood>, <ImmersiveEngineering:material:3>], [<ImmersiveEngineering:material:3>, <ore:stickWood>, <ImmersiveEngineering:material:3>]]);
 	recipes.addShaped(<OpenBlocks:flag> * 3, [[<ore:stickWood>, <terrafirmacraft:item.BurlapCloth>, <terrafirmacraft:item.BurlapCloth>], [<ore:stickWood>, <terrafirmacraft:item.BurlapCloth>, null], [<ore:stickWood>, null, null]]);
+	recipes.addShaped(<OpenBlocks:sleepingBag>, [[<ore:materialCloth>, <ore:materialCloth>, <ore:materialCloth>]]);


### PR DESCRIPTION
I hope it's fine to make a pull request without asking first. I have a minor tweak to help with balancing the OpenBlocks sleeping bag. Right now it takes way too much wool (12 wool cloth, which means 24 wool, vs 3 wool cloth for a normal bed).

But a sleeping bag is not as good as a bed because it doesn't change spawn. Also it's incredibly useful in the early game when exploring and you need somewhere to sleep at night. At 3 cloth, it's something you can actually craft pre-iron if you're willing to kill from 1-3 sheep and use the sheepskin. As it currently stands you'd need to kill between 3 and 9 sheep, which is far less reasonable, or be halfway into the iron age, where a sleeping bag is less useful.

I find it a lot more balanced to change the recipe to just 3 cloth, so that it's basically the same recipe as for a bed, just without the wood planks.
##### Old recipe

![Old recipe](https://i.imgur.com/etKJpgO.png)
##### New recipe

![New recipe](https://i.imgur.com/eAMptsv.png)
